### PR TITLE
Initial startup fix

### DIFF
--- a/tekuti/classifier.scm
+++ b/tekuti/classifier.scm
@@ -114,16 +114,22 @@
      (lambda (feature bogus-count)
        (let ((legit-count (hash-ref legit-features feature 0)))
          (hash-set! log-bogosities feature
-                    (log (/ (/ (+ bogus-count 0.001) total-bogus-features)
-                            (/ (+ legit-count 0.001) total-legit-features))))))
+                    (if (and (> total-bogus-features 0)
+                             (> total-legit-features 0))
+                        (log (/ (/ (+ bogus-count 0.001) total-bogus-features)
+                                (/ (+ legit-count 0.001) total-legit-features)))
+                        0))))
      bogus-features)
     (hash-for-each
      (lambda (feature legit-count)
        (let ((bogus-count (hash-ref bogus-features feature)))
          (unless bogus-count
            (hash-set! log-bogosities feature
-                      (log (/ (/ 0.01 total-bogus-features)
-                              (/ (+ legit-count 0.01) total-legit-features)))))))
+                      (if (and (> total-bogus-features 0)
+                               (> total-legit-features 0))
+                          (log (/ (/ 0.01 total-bogus-features)
+                                  (/ (+ legit-count 0.01) total-legit-features)))
+                          0)))))
      legit-features)
     log-bogosities))
 
@@ -138,8 +144,11 @@
        (let ((bogus-count (hash-ref bogus-features feature 0))
              (legit-count (hash-ref legit-features feature 0)))
          (hash-set! log-bogosities feature
-                    (log (/ (/ (+ bogus-count 0.001) total-bogus-features)
-                            (/ (+ legit-count 0.001) total-legit-features))))))
+                    (if (and  (> total-bogus-features 0)
+                              (> total-legit-features 0))
+                        (log (/ (/ (+ bogus-count 0.001) total-bogus-features)
+                                (/ (+ legit-count 0.001) total-legit-features)))
+                        0))))
      changed-features)))
 
 (define (compute-bogus-probability comment log-bogosities bogus-prior
@@ -250,7 +259,9 @@
   (with-time-debugging
    (let* ((legit-count (hash-count (const #t) legit-comments))
           (bogus-count (hash-count (const #t) bogus-comments))
-          (legit-prior (/ legit-count (+ legit-count bogus-count 0.0)))
+          (legit-prior (if (> legit-count 0)
+                           (/ legit-count (+ legit-count bogus-count 0.0))
+                           0))
           (legit-features (count-features legit-comments))
           (bogus-features (count-features bogus-comments))
           (bogosities (compute-log-bogosities legit-features bogus-features)))

--- a/tekuti/git.scm
+++ b/tekuti/git.scm
@@ -334,7 +334,7 @@
                    (cons (string->symbol k) v))))))
 
 (define (fold-commits f rev seed)
-  (let lp ((rev (git-rev-parse rev)) (seed seed))
+  (let lp ((rev (and rev (git-rev-parse rev))) (seed seed))
     (if rev
         (let ((commit (parse-commit rev)))
           (lp (assq-ref commit 'parent)


### PR DESCRIPTION
Hi!

I'd stopped using Tekuti for a while and when I came back to it I noticed that I couldn't run the latest version of it anymore. I also noticed that a brand new setup had the same issue I did, which essentially comes down to the fact that there is no comment classification data for anything, and (as you can see through the second commit) there was an assumption that there would always be at least 1 commit in the git repository.

I honestly can't say I fully understand the code in `classifier.scm`, so if I'm going about this the entirely wrong way, please let me know, but these changes got both my collection of posts working again, and also made it possible for me to start up a new setup.